### PR TITLE
Feat1

### DIFF
--- a/C2_Sticky/Source/App/C2_StickyApp.swift
+++ b/C2_Sticky/Source/App/C2_StickyApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct C2_StickyApp: App {
     var body: some Scene {
         WindowGroup {
-            
+            ContentView()
         }
     }
 }

--- a/C2_Sticky/Source/Core/Extension/Extension + View.swift
+++ b/C2_Sticky/Source/Core/Extension/Extension + View.swift
@@ -1,0 +1,14 @@
+//
+//  Extension + View.swift
+//  C2_Sticky
+//
+//  Created by 성일 on 4/15/25.
+//
+
+import SwiftUI
+
+extension View {
+    func focusedTextFieldLayout(isFocused: Bool) -> some View {
+        self.modifier(RoundedFocusedTextField(isFocused: isFocused))
+    }
+}

--- a/C2_Sticky/Source/Core/Extension/Extension + View.swift
+++ b/C2_Sticky/Source/Core/Extension/Extension + View.swift
@@ -8,11 +8,37 @@
 import SwiftUI
 
 extension View {
+    // Modifier Method
+    /// 텍스트 필드에 포커스 상태에 따라 스타일을 적용합니다.
+    /// 이 Modifier는 텍스트 필드의 포커스 상태에 따라 테두리 색상을 변경합니다.
+    /// 포커스가 있을 때는 mainColor 테두리가 적용되고, 포커스가 없을 때는 gray가 적용됩니다.
+    /// - Parameter isFocused: 텍스트 필드의 현재 포커스 상태
+    /// - Returns: 포커스 상태에 따라 스타일이 적용된 수정된 뷰
+    /// ```
+    /// TextField("이메일을 입력해주세요.", text: $email)
+    ///     .focused($isFocusedEmail)
+    ///     .padding()
+    ///     .focusedTextFieldLayout(isFocused: isFocusedEmail)
+    /// ```
     func focusedTextFieldLayout(isFocused: Bool) -> some View {
         self.modifier(RoundedFocusedTextField(isFocused: isFocused))
     }
     
+    /// View에 Tap하여 키보드를 숨기는 기능을 추가합니다.
+    /// 이 Modifier는 뷰의 모든 영역(포함된 자식 뷰 영역 포함)에서 탭 제스처가 발생했을 때
+    /// 키보드를 화면에서 내립니다. 텍스트 필드나 텍스트 에디터에 입력 중인 상태에서
+    /// 화면의 아무 곳이나 탭하면 키보드가 사라집니다.
+    /// - Returns: 키보드 숨김 기능이 추가된 수정된 뷰
+    /// - Note: 이 수정자는 ScrollView가 없는 일반 뷰에서 가장 효과적으로 작동합니다.
     func didTapToDismissKeyboard() -> some View {
         self.modifier(KeyboardDismissModifier())
     }
-}
+    
+    // Method
+    /// 키보드를 화면에서 숨깁니다.
+    /// 이 함수는 현재 첫 번째 응답자(first responder)에게 resignFirstResponder 메시지를 전송하여
+    /// 키보드가 화면에서 사라지도록 합니다.
+    /// - Note: 이 메서드는 텍스트 필드나 텍스트 뷰와 같은 입력 필드에 포커스가 있을 때 키보드를 내리는 데 사용됩니다.
+    func didHideKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }}

--- a/C2_Sticky/Source/Core/Extension/Extension + View.swift
+++ b/C2_Sticky/Source/Core/Extension/Extension + View.swift
@@ -11,4 +11,8 @@ extension View {
     func focusedTextFieldLayout(isFocused: Bool) -> some View {
         self.modifier(RoundedFocusedTextField(isFocused: isFocused))
     }
+    
+    func didTapToDismissKeyboard() -> some View {
+        self.modifier(KeyboardDismissModifier())
+    }
 }

--- a/C2_Sticky/Source/Core/Modifier/KeyboardDismissModifier.swift
+++ b/C2_Sticky/Source/Core/Modifier/KeyboardDismissModifier.swift
@@ -1,0 +1,25 @@
+//
+//  Untitled.swift
+//  C2_Sticky
+//
+//  Created by 성일 on 4/16/25.
+//
+
+import SwiftUI
+
+struct KeyboardDismissModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        didTapToDismissKeyboard()
+                    }
+            )
+    }
+    
+    private func didTapToDismissKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}

--- a/C2_Sticky/Source/Core/Modifier/TextFieldModifier.swift
+++ b/C2_Sticky/Source/Core/Modifier/TextFieldModifier.swift
@@ -1,0 +1,21 @@
+//
+//  TextFieldModifier.swift
+//  C2_Sticky
+//
+//  Created by 성일 on 4/15/25.
+//
+
+import SwiftUI
+
+struct RoundedFocusedTextField: ViewModifier {
+    let isFocused: Bool
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isFocused ? Color.mainYellow : Color.mainGray)
+            }
+    }
+}
+

--- a/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
@@ -34,6 +34,7 @@ struct LoginView: View {
                     .padding()
                     .font(.body5)
                     .focusedTextFieldLayout(isFocused: isFocusedEmail)
+                    .keyboardType(.emailAddress)
             }
             
             VStack(alignment: .leading, spacing: 8) {

--- a/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
@@ -1,0 +1,81 @@
+//
+//  LoginView.swift
+//  C2_Sticky
+//
+//  Created by 성일 on 4/15/25.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+    @State private var email: String = ""
+    @State private var password: String = ""
+    
+    @FocusState private var isFocusedEmail: Bool
+    @FocusState private var isFocusedPassword: Bool
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+            
+            Text("Sticky")
+                .font(.main)
+                .foregroundStyle(Color.mainYellow)
+            
+            Spacer()
+            
+            VStack(alignment: .leading, spacing: 8) {
+                Text("이메일")
+                    .font(.body4)
+                    .padding(.leading, 8)
+                
+                TextField("이메일을 입력해주세요.", text: $email)
+                    .focused($isFocusedEmail)
+                    .padding()
+                    .focusedTextFieldLayout(isFocused: isFocusedEmail)
+            }
+            
+            VStack(alignment: .leading, spacing: 8) {
+                Text("비밀번호")
+                    .font(.body4)
+                    .padding(.leading, 8)
+                
+                SecureField("비밀번호를 입력해주세요.", text: $password)
+                    .focused($isFocusedPassword)
+                    .padding()
+                    .focusedTextFieldLayout(isFocused: isFocusedPassword)
+            }
+            
+            Spacer()
+            
+            Button("로그인") {
+                
+            }
+            .frame(maxWidth: .infinity, maxHeight: 55)
+            .foregroundStyle(.white)
+            .background(Color.mainYellow)
+            .clipShape(.rect(cornerRadius: 12))
+            
+            Spacer()
+            
+            VStack(spacing: 8) {
+                Text("Or Sign up With")
+                    .font(.body5)
+                    .foregroundStyle(.gray)
+                
+                Button("Sign up") {
+                    
+                }
+                .foregroundStyle(Color.mainYellow)
+                .font(.h4)
+            }
+            
+            Spacer()
+            
+        }.padding(.horizontal, 16)
+    }
+}
+
+#Preview {
+    LoginView()
+}

--- a/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
@@ -15,68 +15,69 @@ struct LoginView: View {
     @FocusState private var isFocusedPassword: Bool
     
     var body: some View {
-        VStack(spacing: 24) {
-            Spacer()
-            
-            Text("Sticky")
-                .font(.main)
-                .foregroundStyle(Color.mainYellow)
-            
-            Spacer()
-            
-            VStack(alignment: .leading, spacing: 8) {
-                Text("이메일")
-                    .font(.body5)
-                    .padding(.leading, 8)
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
                 
-                TextField("이메일을 입력해주세요.", text: $email)
-                    .focused($isFocusedEmail)
-                    .padding()
-                    .font(.body5)
-                    .focusedTextFieldLayout(isFocused: isFocusedEmail)
-                    .keyboardType(.emailAddress)
-            }
-            
-            VStack(alignment: .leading, spacing: 8) {
-                Text("비밀번호")
-                    .font(.body5)
-                    .padding(.leading, 8)
+                Text("Sticky")
+                    .font(.main)
+                    .foregroundStyle(Color.mainYellow)
                 
-                SecureField("비밀번호를 입력해주세요.", text: $password)
-                    .focused($isFocusedPassword)
-                    .padding()
-                    .font(.body5)
-                    .focusedTextFieldLayout(isFocused: isFocusedPassword)
-            }
-            
-            Spacer()
-            
-            Button("로그인") {
+                Spacer()
                 
-            }
-            .font(.h4)
-            .frame(maxWidth: .infinity, maxHeight: 55)
-            .foregroundStyle(.white)
-            .background(Color.mainYellow)
-            .clipShape(.rect(cornerRadius: 12))
-            
-            Spacer()
-            
-            VStack(spacing: 8) {
-                Text("Or Sign up With")
-                    .font(.body5)
-                    .foregroundStyle(.gray)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("이메일")
+                        .font(.body5)
+                        .padding(.leading, 8)
+                    
+                    TextField("이메일을 입력해주세요.", text: $email)
+                        .focused($isFocusedEmail)
+                        .padding()
+                        .font(.body5)
+                        .focusedTextFieldLayout(isFocused: isFocusedEmail)
+                        .keyboardType(.emailAddress)
+                }
                 
-                Button("Sign up") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("비밀번호")
+                        .font(.body5)
+                        .padding(.leading, 8)
+                    
+                    SecureField("비밀번호를 입력해주세요.", text: $password)
+                        .focused($isFocusedPassword)
+                        .padding()
+                        .font(.body5)
+                        .focusedTextFieldLayout(isFocused: isFocusedPassword)
+                }
+                
+                Spacer()
+                
+                Button("로그인") {
                     
                 }
-                .foregroundStyle(Color.mainYellow)
                 .font(.h4)
-            }
+                .frame(maxWidth: .infinity, maxHeight: 55)
+                .foregroundStyle(.white)
+                .background(Color.mainYellow)
+                .clipShape(.rect(cornerRadius: 12))
+                
+                Spacer()
+                
+                VStack(spacing: 8) {
+                    Text("Or Sign up With")
+                        .font(.body5)
+                        .foregroundStyle(.gray)
+                    
+                    NavigationLink( destination: RegisterView()) {
+                        Text("Sign up")
+                    }
+                    .foregroundStyle(Color.mainYellow)
+                    .font(.h4)
+                }
+                Spacer()
+            }.padding(.horizontal, 16)
             
-            Spacer()
-            
-        }.padding(.horizontal, 16)
+        }
     }
 }
 

--- a/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
@@ -78,7 +78,6 @@ struct LoginView: View {
             }
             .padding(.horizontal, 16)
             .didTapToDismissKeyboard()
-            .ignoresSafeArea()
         }
     }
 }

--- a/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
@@ -26,23 +26,25 @@ struct LoginView: View {
             
             VStack(alignment: .leading, spacing: 8) {
                 Text("이메일")
-                    .font(.body4)
+                    .font(.body5)
                     .padding(.leading, 8)
                 
                 TextField("이메일을 입력해주세요.", text: $email)
                     .focused($isFocusedEmail)
                     .padding()
+                    .font(.body5)
                     .focusedTextFieldLayout(isFocused: isFocusedEmail)
             }
             
             VStack(alignment: .leading, spacing: 8) {
                 Text("비밀번호")
-                    .font(.body4)
+                    .font(.body5)
                     .padding(.leading, 8)
                 
                 SecureField("비밀번호를 입력해주세요.", text: $password)
                     .focused($isFocusedPassword)
                     .padding()
+                    .font(.body5)
                     .focusedTextFieldLayout(isFocused: isFocusedPassword)
             }
             
@@ -51,6 +53,7 @@ struct LoginView: View {
             Button("로그인") {
                 
             }
+            .font(.h4)
             .frame(maxWidth: .infinity, maxHeight: 55)
             .foregroundStyle(.white)
             .background(Color.mainYellow)

--- a/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Login/LoginView.swift
@@ -75,8 +75,10 @@ struct LoginView: View {
                     .font(.h4)
                 }
                 Spacer()
-            }.padding(.horizontal, 16)
-            
+            }
+            .padding(.horizontal, 16)
+            .didTapToDismissKeyboard()
+            .ignoresSafeArea()
         }
     }
 }

--- a/C2_Sticky/Source/Features/Authorization/Register/RegisterView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Register/RegisterView.swift
@@ -1,0 +1,18 @@
+//
+//  RegisterView.swift
+//  C2_Sticky
+//
+//  Created by 성일 on 4/15/25.
+//
+
+import SwiftUI
+
+struct RegisterView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    RegisterView()
+}

--- a/C2_Sticky/Source/Features/Authorization/Register/RegisterView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Register/RegisterView.swift
@@ -23,109 +23,113 @@ struct RegisterView: View {
     @FocusState private var isFocusedPassword: Bool
     
     var body: some View {
-        VStack(alignment: .leading) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text("프로필을 등록해주세요.")
-                    .font(.h4)
-                Text("닉네임은 아카데미에서 사용하는 닉네임을 영어로 작성해주세요.")
-                    .font(.body5)
-                    .foregroundStyle(Color.gray)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
-            }
-            
-            Spacer()
-            
-            HStack {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
                 Spacer()
-                PhotosPicker(selection: $selectedItem, matching: .images) {
-                    
-                    if let image = selectedImage {
-                        Image(uiImage: image)
-                            .resizable()
-                            .scaledToFill()
-                            .frame(width: 120, height: 120)
-                            .clipShape(Circle())
-                    } else {
-                        Image(systemName: "camera")
-                            .resizable()
-                            .frame(width: 25, height: 20)
-                            .foregroundStyle(.gray)
-                    }
-                    
+                
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("프로필을 등록해주세요.")
+                        .font(.h4)
+                    Text("닉네임은 아카데미에서 사용하는 닉네임을 영어로 작성해주세요.")
+                        .font(.body5)
+                        .foregroundStyle(Color.gray)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
                 }
-                .frame(width: 120, height: 120)
-                .background(Color.milkGray)
-                .clipShape(Circle())
-                .onChange(of: selectedItem) { _, newValue in
-                    Task {
-                        if let data = try? await newValue?.loadTransferable(type: Data.self),
-                           let uiImage = UIImage(data: data) {
-                            selectedImage = uiImage
+                
+                HStack {
+                    Spacer()
+                    PhotosPicker(selection: $selectedItem, matching: .images) {
+                        
+                        if let image = selectedImage {
+                            Image(uiImage: image)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 120, height: 120)
+                                .clipShape(Circle())
+                        } else {
+                            Image(systemName: "camera")
+                                .resizable()
+                                .frame(width: 25, height: 20)
+                                .foregroundStyle(.gray)
                         }
                     }
+                    .frame(width: 120, height: 120)
+                    .background(Color.milkGray)
+                    .clipShape(Circle())
+                    .onChange(of: selectedItem) { _, newValue in
+                        Task {
+                            if let data = try? await newValue?.loadTransferable(type: Data.self),
+                               let uiImage = UIImage(data: data) {
+                                selectedImage = uiImage
+                            }
+                        }
+                    }
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 60)
+                            .stroke(Color.black.opacity(0.2))
+                    }
+                    Spacer()
                 }
-                .overlay {
-                    RoundedRectangle(cornerRadius: 60)
-                        .stroke(Color.black.opacity(0.2))
+                .padding(.vertical, 16)
+                
+                VStack(spacing: 16) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("닉네임")
+                            .font(.body5)
+                            .padding(.leading, 8)
+                        
+                        TextField("닉네임을 입력해주세요.", text: $nickname)
+                            .focused($isFocusedNickname)
+                            .padding()
+                            .font(.body5)
+                            .focusedTextFieldLayout(isFocused: isFocusedNickname)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("이메일")
+                            .font(.body5)
+                            .padding(.leading, 8)
+                        
+                        TextField("이메일을 입력해주세요.", text: $email)
+                            .font(.body5)
+                            .keyboardType(.emailAddress)
+                            .focused($isFocusedEmail)
+                            .padding()
+                            .focusedTextFieldLayout(isFocused: isFocusedEmail)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("비밀번호")
+                            .font(.body5)
+                            .padding(.leading, 8)
+                        
+                        SecureField("비밀번호를 입력해주세요.", text: $password)
+                            .font(.body5)
+                            .focused($isFocusedPassword)
+                            .padding()
+                            .focusedTextFieldLayout(isFocused: isFocusedPassword)
+                    }
                 }
+                
+                Spacer().frame(minHeight: 30)
+                
+                Button("로그인") {
+                    
+                }
+                .frame(maxWidth: .infinity, maxHeight: 55)
+                .foregroundStyle(.white)
+                .background(Color.mainYellow)
+                .clipShape(.rect(cornerRadius: 12))
                 Spacer()
             }
-            
-            Spacer()
-            
-            VStack(spacing: 12) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("닉네임")
-                        .font(.body5)
-                        .padding(.leading, 8)
-                    
-                    TextField("닉네임을 입력해주세요.", text: $nickname)
-                        .focused($isFocusedNickname)
-                        .padding()
-                        .font(.body5)
-                        .focusedTextFieldLayout(isFocused: isFocusedNickname)
-                }
-                
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("이메일")
-                        .font(.body5)
-                        .padding(.leading, 8)
-                    
-                    TextField("이메일을 입력해주세요.", text: $email)
-                        .font(.body5)
-                        .focused($isFocusedEmail)
-                        .padding()
-                        .focusedTextFieldLayout(isFocused: isFocusedEmail)
-                }
-                
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("비밀번호")
-                        .font(.body5)
-                        .padding(.leading, 8)
-                    
-                    SecureField("비밀번호를 입력해주세요.", text: $password)
-                        .font(.body5)
-                        .focused($isFocusedPassword)
-                        .padding()
-                        .focusedTextFieldLayout(isFocused: isFocusedPassword)
-                }
-            }
-            
-            Spacer()
-            
-            Button("로그인") {
-                
-            }
-            .frame(maxWidth: .infinity, maxHeight: 55)
-            .foregroundStyle(.white)
-            .background(Color.mainYellow)
-            .clipShape(.rect(cornerRadius: 12))
-            
-            Spacer()
+            .padding(.horizontal, 16)
+            .frame(minHeight: UIScreen.main.bounds.height - 100)
         }
-        .padding(.horizontal, 16)
-        .didTapToDismissKeyboard()
+        .simultaneousGesture(TapGesture().onEnded {
+            didHideKeyboard()
+        })
+        .scrollDismissesKeyboard(.immediately)
         .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {

--- a/C2_Sticky/Source/Features/Authorization/Register/RegisterView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Register/RegisterView.swift
@@ -6,12 +6,127 @@
 //
 
 import SwiftUI
+import PhotosUI
 
 struct RegisterView: View {
+    @State private var nickname: String = ""
+    @State private var email: String = ""
+    @State private var password: String = ""
+    
+    @FocusState private var isFocusedNickname: Bool
+    @FocusState private var isFocusedEmail: Bool
+    @FocusState private var isFocusedPassword: Bool
+    
+    @State private var selectedItem: PhotosPickerItem? = nil
+    @State private var selectedImage: UIImage? = nil
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(alignment: .leading) {
+            Spacer()
+            
+            VStack(alignment: .leading, spacing: 8) {
+                Text("프로필을 등록해주세요.")
+                    .font(.h4)
+                Text("닉네임은 아카데미에서 사용하는 닉네임을 영어로 작성해주세요.")
+                    .font(.body5)
+                    .foregroundStyle(Color.gray)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+            
+            Spacer()
+            
+            HStack {
+                Spacer()
+                PhotosPicker(selection: $selectedItem, matching: .images) {
+                    
+                    if let image = selectedImage {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 120, height: 120)
+                            .clipShape(Circle())
+                    } else {
+                        Image(systemName: "camera")
+                            .resizable()
+                            .frame(width: 25, height: 20)
+                            .foregroundStyle(.gray)
+                    }
+                    
+                }
+                .frame(width: 120, height: 120)
+                .background(Color.milkGray)
+                .clipShape(Circle())
+                .onChange(of: selectedItem) { _, newValue in
+                    Task {
+                        if let data = try? await newValue?.loadTransferable(type: Data.self),
+                           let uiImage = UIImage(data: data) {
+                            selectedImage = uiImage
+                        }
+                    }
+                }
+                .overlay {
+                    RoundedRectangle(cornerRadius: 60)
+                        .stroke(Color.black.opacity(0.2))
+                }
+                Spacer()
+            }
+            
+            Spacer()
+            
+            VStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("닉네임")
+                        .font(.body5)
+                        .padding(.leading, 8)
+                    
+                    TextField("닉네임을 입력해주세요.", text: $nickname)
+                        .focused($isFocusedNickname)
+                        .padding()
+                        .font(.body5)
+                        .focusedTextFieldLayout(isFocused: isFocusedNickname)
+                }
+                
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("이메일")
+                        .font(.body5)
+                        .padding(.leading, 8)
+                    
+                    TextField("이메일을 입력해주세요.", text: $email)
+                        .font(.body5)
+                        .focused($isFocusedEmail)
+                        .padding()
+                        .focusedTextFieldLayout(isFocused: isFocusedEmail)
+                }
+                
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("비밀번호")
+                        .font(.body5)
+                        .padding(.leading, 8)
+                    
+                    SecureField("비밀번호를 입력해주세요.", text: $password)
+                        .font(.body5)
+                        .focused($isFocusedPassword)
+                        .padding()
+                        .focusedTextFieldLayout(isFocused: isFocusedPassword)
+                }
+            }
+            
+            Spacer()
+            
+            Button("로그인") {
+                
+            }
+            .frame(maxWidth: .infinity, maxHeight: 55)
+            .foregroundStyle(.white)
+            .background(Color.mainYellow)
+            .clipShape(.rect(cornerRadius: 12))
+            
+            Spacer()
+        }.padding(.horizontal, 16)
     }
 }
+
 
 #Preview {
     RegisterView()

--- a/C2_Sticky/Source/Features/Authorization/Register/RegisterView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Register/RegisterView.swift
@@ -125,6 +125,7 @@ struct RegisterView: View {
             Spacer()
         }
         .padding(.horizontal, 16)
+        .didTapToDismissKeyboard()
         .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {

--- a/C2_Sticky/Source/Features/Authorization/Register/RegisterView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Register/RegisterView.swift
@@ -9,21 +9,21 @@ import SwiftUI
 import PhotosUI
 
 struct RegisterView: View {
+    @Environment(\.dismiss) private var dismiss
+    
     @State private var nickname: String = ""
     @State private var email: String = ""
     @State private var password: String = ""
+    
+    @State private var selectedItem: PhotosPickerItem? = nil
+    @State private var selectedImage: UIImage? = nil
     
     @FocusState private var isFocusedNickname: Bool
     @FocusState private var isFocusedEmail: Bool
     @FocusState private var isFocusedPassword: Bool
     
-    @State private var selectedItem: PhotosPickerItem? = nil
-    @State private var selectedImage: UIImage? = nil
-    
     var body: some View {
         VStack(alignment: .leading) {
-            Spacer()
-            
             VStack(alignment: .leading, spacing: 8) {
                 Text("프로필을 등록해주세요.")
                     .font(.h4)
@@ -123,10 +123,23 @@ struct RegisterView: View {
             .clipShape(.rect(cornerRadius: 12))
             
             Spacer()
-        }.padding(.horizontal, 16)
+        }
+        .padding(.horizontal, 16)
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    HStack {
+                        Image(systemName: "chevron.left")
+                            .foregroundStyle(Color.primary)
+                    }
+                }
+            }
+        }
     }
 }
-
 
 #Preview {
     RegisterView()

--- a/C2_Sticky/Source/Features/Authorization/Splash/SplashView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Splash/SplashView.swift
@@ -1,0 +1,18 @@
+//
+//  SplashView.swift
+//  C2_Sticky
+//
+//  Created by 성일 on 4/15/25.
+//
+
+import SwiftUI
+
+struct SplashView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    SplashView()
+}

--- a/C2_Sticky/Source/Features/Authorization/Splash/SplashView.swift
+++ b/C2_Sticky/Source/Features/Authorization/Splash/SplashView.swift
@@ -9,7 +9,14 @@ import SwiftUI
 
 struct SplashView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ZStack {
+            Color.mainYellow
+        
+            Text("Sticky")
+                .font(.main)
+                .foregroundStyle(.white)
+        }
+        .ignoresSafeArea()
     }
 }
 

--- a/C2_Sticky/Source/Features/ContentView.swift
+++ b/C2_Sticky/Source/Features/ContentView.swift
@@ -1,0 +1,32 @@
+//
+//  ContentView.swift
+//  C2_Sticky
+//
+//  Created by 성일 on 4/15/25.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    @State var isLaunch: Bool = true
+    
+    var body: some View {
+        
+        if isLaunch {
+            SplashView()
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                        withAnimation(.linear) {
+                            self.isLaunch = false
+                        }
+                    }
+                }
+        } else {
+            LoginView()
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
1. SplashView
- SplashView UI를 구현했습니다.
- Splash가 동작하도록 구현했습니다.

2. LoginView
- LoginView UI를 구현했습니다.
- LoginView -> RegisterView 네비게이션 스택을 구현했습니다.
- 텍스트필드에 포커스가 발생하면 테두리 색상이 변경되도록 구현했습니다.

4. RegisterView 
- RegisterView UI를 구현했습니다.
- PhotosPicker를 통해 이미지를 선택할 수 있고, 선택 된 이미지로 Picker버튼이 변경되도록 구현했습니다.
- 텍스트필드에 포커스가 발생하면 테두리 색상이 변경되도록 구현했습니다.

5. Communal
- TextField 스타일링을 위한 ViewModifier를 구현했습니다.
- Keyborad dismiss를 위한 ViewModifier와 메소드를 구현했습니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

| SplashView | LoginView | RegisterView |
|------------|-----------|--------------|
| ![Simulator Screen Recording - iPhone 16 - 2025-04-16 at 10 39 59](https://github.com/user-attachments/assets/56090794-a396-40b5-9beb-07ebd5055164) | ![Simulator Screen Recording - iPhone 16 - 2025-04-16 at 11 08 28](https://github.com/user-attachments/assets/9455436e-26bf-4f18-8ead-3891cb643058) | ![Simulator Screen Recording - iPhone 16 - 2025-04-16 at 11 45 49](https://github.com/user-attachments/assets/60e3699d-fea2-459f-805f-ef436e47b4a7) |

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
1. ViewModifier에 대해서 어떻게 생각하시나요?
개인적으로 선언형 언어인 SwiftUI에서 Modifier는 굉장히 중요한 요소라고 생각합니다. UIKit과 가장 크게 차별화되는 점이기도 하고, 실제로 사용해 보면 더 편리한 면도 많습니다. 그래서 UI 스타일링을 재사용하거나 UI 코드가 길어질 경우, ViewModifier를 구현해서 활용하는 것이 꽤 유용하다는 생각이 드는데요. 다른 분들은 어떻게 생각하시나요?

| ViewModifier | Common | 
|------------|------------|
| <img width="853" alt="스크린샷 2025-04-16 오전 11 52 38" src="https://github.com/user-attachments/assets/c7768744-2d8e-49a0-a174-f8bca1a426c8" /> | <img width="703" alt="스크린샷 2025-04-16 오전 11 59 16" src="https://github.com/user-attachments/assets/50107647-968d-4fc0-9f0b-829e70411c85" /> |

2. 키보드가 특정 부분에서 내려가지 않는 문제가 발생했습니다. 
```
struct KeyboardDismissModifier: ViewModifier {
    func body(content: Content) -> some View {
        content
            .background(
                Color.clear
                    .contentShape(Rectangle())
                    .onTapGesture {
                        didTapToDismissKeyboard()
                    }
            )
    }
    
    private func didTapToDismissKeyboard() {
        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
    }
}
```
onTapGesture가 뷰의 일부 영역에만 적용되기 때문에 발생하는 것 같아서 제가 수정해봤는데 맞는 방법인지 궁금합니다. 
(이 코드도 마찬가지로 Modifier로 구현해봤어요)

Logic : 전체 뷰의 배경에 새로운 투명 레이어를 추가 -> 기본적으로 투명한 영역은 TapGesture를 인식하지 않지만, contentShape은 투명하더라도 전체 사각형 영역이 Tap 가능하도록 합니다 -> 투명한 전체 배경 영역에 TapGesture를 처리합니다.

4. SwiftUI에서 키보드가 올라오거나 특정 이벤트가 발생해서 화면을 가린다면 뷰가 자동으로 올라가네요.. 대부분의 경우 사용자 경험을 개선하기 위한 것이라 중요하다고 생각은 합니다만.. 제가 구현한 페이지에는 해당 이벤트가 발생하면 원치 않는 레이아웃 변화를 일으켜서 스크롤 뷰를 채택했는데, 맞는 방법인지 궁금합니다.

5. 네비게이션 백 버튼 커스텀할 때 따로 커스텀 뷰를 구현하시는지 툴바를 사용하는지 궁금합니다
툴바는 iOS 16부터 지원하는데 그냥 프바프인가 궁금해요

```
.toolbar {
            ToolbarItem(placement: .navigationBarLeading) {
                Button {
                    dismiss()
                } label: {
                    HStack {
                        Image(systemName: "chevron.left")
                            .foregroundStyle(Color.primary)
                    }
                }
            }
        }
```

## Resolved
Resolved: #2 

